### PR TITLE
Add ABI for vet.domains resolve utilities

### DIFF
--- a/ABIs/vet-domains-ResolveUtilities.json
+++ b/ABIs/vet-domains-ResolveUtilities.json
@@ -1,0 +1,59 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string[]",
+        "name": "names",
+        "type": "string[]"
+      }
+    ],
+    "name": "getAddresses",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "addresses",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "addresses",
+        "type": "address[]"
+      }
+    ],
+    "name": "getNames",
+    "outputs": [
+      {
+        "internalType": "string[]",
+        "name": "names",
+        "type": "string[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string[]",
+        "name": "names",
+        "type": "string[]"
+      }
+    ],
+    "name": "getNamehashes",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "nodes",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
This PR adds the public interfaces for the vet.domains resolve utilities (https://docs.vet.domains/Developers/Contracts/Resolve-Utils/) that allow a simpler way to resolve names or addresses.