### PR TITLE
Feat: VeBetterPassport v4 changes

### DIFF
--- a/ABIs/VeBetterDAO-ve-better-passport.json
+++ b/ABIs/VeBetterDAO-ve-better-passport.json
@@ -777,6 +777,19 @@
   },
   {
     "inputs": [],
+    "name": "RESET_SIGNALER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "ROLE_GRANTER",
     "outputs": [
       {
@@ -1605,6 +1618,11 @@
             "internalType": "address",
             "name": "actionScoreManager",
             "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "resetSignaler",
+            "type": "address"
           }
         ],
         "internalType": "struct PassportTypes.InitializationRoleData",
@@ -1613,6 +1631,19 @@
       }
     ],
     "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_resetSignaler",
+        "type": "address"
+      }
+    ],
+    "name": "initializeV4",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2177,7 +2208,7 @@
         "type": "string"
       }
     ],
-    "name": "resetUserSignalsByAppAdminWithReason",
+    "name": "resetUserSignalsByAppWithReason",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"


### PR DESCRIPTION
## Upgrade `VeBetterPassport` to Version 4

This upgrade adds a new role for signal reset functionality and improves access control for signaling functions. It also fixes an arithmetic underflow issue when resetting signals.

### Changes 🚀

- **Upgraded Contract(s):**
  - `VeBetterPassport.sol` to version `4`

### Storage Changes 📦

- None.

### New Features 🚀

- **`VeBetterPassport`**:
  - Added `RESET_SIGNALER_ROLE` initialization
  - Extended `resetUserSignalsWithReason` function to be used by the `RESET_SIGNALER_ROLE`
  - Restricted `signalUser` function to `DEFAULT_ADMIN_ROLE`
  - Restricted `signalUserWithReason` function to `SIGNALER_ROLE`
  - Renamed `resetUserSignalsByAppAdminWithReason` to `resetUserSignalsByAppWithReason` to be used by `SIGNALER_ROLE`
  - Added `initializeV4()` function to initialize the new role

### Bug Fixes 🐛

- **`VeBetterPassport`**:
  - Fixed arithmetic underflow when resetting signals, which could occur when app admin resets signal count after default admin in sequence
