### PR TITLE
feat: update X2EarnRewardsPool ABI for V8

### DIFF
--- a/ABIs/VeBetterDAO-x-2-earn-rewards-pool.json
+++ b/ABIs/VeBetterDAO-x-2-earn-rewards-pool.json
@@ -701,6 +701,39 @@
         "type": "address"
       },
       {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actionRound",
+        "type": "uint256"
+      }
+    ],
+    "name": "distributeRewardForRound",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "appId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
         "internalType": "string[]",
         "name": "proofTypes",
         "type": "string[]"
@@ -780,6 +813,117 @@
       }
     ],
     "name": "distributeRewardWithProofAndMetadata",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "appId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "string[]",
+        "name": "proofTypes",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "proofValues",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "impactCodes",
+        "type": "string[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "impactValues",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "metadata",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actionRound",
+        "type": "uint256"
+      }
+    ],
+    "name": "distributeRewardWithProofAndMetadataForRound",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "appId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "string[]",
+        "name": "proofTypes",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "proofValues",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "impactCodes",
+        "type": "string[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "impactValues",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actionRound",
+        "type": "uint256"
+      }
+    ],
+    "name": "distributeRewardWithProofForRound",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1219,6 +1363,19 @@
       }
     ],
     "name": "setX2EarnApps",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IXAllocationVotingGovernor",
+        "name": "_xAllocationVoting",
+        "type": "address"
+      }
+    ],
+    "name": "setXAllocationVoting",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"


### PR DESCRIPTION
## Summary

- Update X2EarnRewardsPool ABI with V8 functions: `distributeRewardForRound`, `distributeRewardWithProofForRound`, `distributeRewardWithProofAndMetadataForRound`, and `setXAllocationVoting`
- Related: https://github.com/vechain/vebetterdao/pull/3368


Made with [Cursor](https://cursor.com)