### PR TITLE
feat: sync VeBetterDAO ABIs with v10/v11 contract upgrades

### DIFF
--- a/ABIs/VeBetterDAO-b3tr-challenges.json
+++ b/ABIs/VeBetterDAO-b3tr-challenges.json
@@ -545,6 +545,22 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "NotVerifiedPerson",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "challengeId",
         "type": "uint256"

--- a/ABIs/VeBetterDAO-b3tr-governor.json
+++ b/ABIs/VeBetterDAO-b3tr-governor.json
@@ -428,6 +428,22 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "InvalidPayeeAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MissingProposalBudget",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -460,8 +476,57 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotReadyToClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "PayeesAlreadyFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "PayoutAlreadyClaimed",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "QueueEmpty",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "provided",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "TooManyContributors",
     "type": "error"
   },
   {
@@ -489,6 +554,22 @@
       }
     ],
     "name": "UnauthorizedAccess",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnauthorizedCommunityExecution",
     "type": "error"
   },
   {
@@ -621,6 +702,25 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxBudget",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProposalBudgetSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "uint256",
         "name": "proposalId",
@@ -666,6 +766,25 @@
       }
     ],
     "name": "ProposalCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string[]",
+        "name": "contributors",
+        "type": "string[]"
+      }
+    ],
+    "name": "ProposalContributorsSet",
     "type": "event"
   },
   {
@@ -810,6 +929,62 @@
       }
     ],
     "name": "ProposalInDevelopment",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "implementationDiscussion",
+        "type": "string"
+      }
+    ],
+    "name": "ProposalInDevelopmentDetails",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProposalPayoutClaimed",
     "type": "event"
   },
   {
@@ -1424,6 +1599,19 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "claimPayout",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "clock",
     "outputs": [
@@ -1616,12 +1804,107 @@
         "type": "uint256"
       }
     ],
+    "name": "getProposalBudget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProposalContributors",
+    "outputs": [
+      {
+        "internalType": "string[]",
+        "name": "",
+        "type": "string[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
     "name": "getProposalDeposits",
     "outputs": [
       {
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProposalDescription",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProposalImplementationDiscussion",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProposalPayee",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -1914,6 +2197,24 @@
   {
     "inputs": [
       {
+        "internalType": "contract ITreasury",
+        "name": "_treasury",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxContributorsPerProposal",
+        "type": "uint256"
+      }
+    ],
+    "name": "initializeV11",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "target",
         "type": "address"
@@ -1925,6 +2226,25 @@
       }
     ],
     "name": "isFunctionWhitelisted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "isProposalPaid",
     "outputs": [
       {
         "internalType": "bool",
@@ -1986,6 +2306,26 @@
         "internalType": "uint256",
         "name": "proposalId",
         "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "implementationDiscussion",
+        "type": "string"
+      },
+      {
+        "internalType": "string[]",
+        "name": "contributors",
+        "type": "string[]"
       }
     ],
     "name": "markAsInDevelopment",
@@ -2413,6 +2753,11 @@
       {
         "internalType": "uint256",
         "name": "depositAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxBudget",
         "type": "uint256"
       }
     ],
@@ -3104,6 +3449,39 @@
   {
     "inputs": [],
     "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "implementationDiscussion",
+        "type": "string"
+      },
+      {
+        "internalType": "string[]",
+        "name": "contributors",
+        "type": "string[]"
+      }
+    ],
+    "name": "updateCommunityExecution",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/ABIs/VeBetterDAO-navigator-registry.json
+++ b/ABIs/VeBetterDAO-navigator-registry.json
@@ -290,6 +290,27 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "citizen",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientUnlockedBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint8",
         "name": "decision",
         "type": "uint8"
@@ -1310,6 +1331,19 @@
       }
     ],
     "name": "claimFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "citizens",
+        "type": "address[]"
+      }
+    ],
+    "name": "correctOverDelegations",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/ABIs/VeBetterDAO-x-allocations-voting.json
+++ b/ABIs/VeBetterDAO-x-allocations-voting.json
@@ -325,6 +325,22 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "roundId",
+        "type": "uint256"
+      }
+    ],
+    "name": "VoteAlreadyProcessed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "person",
         "type": "address"
       }


### PR DESCRIPTION
Updates 4 VeBetterDAO ABIs after recent contract upgrades.

- B3TRGovernor V11: community execution framework — adds claimPayout, payee/budget/contributors getters, initializeV11; propose and markAsInDevelopment signatures changed
- XAllocationVoting V10: adds VoteAlreadyProcessed error (relayer double-vote guard)
- NavigatorRegistry V1: adds InsufficientUnlockedBalance error and correctOverDelegations function
- B3TRChallenges V2: adds NotVerifiedPerson error (passport gating)

Source: artifacts compiled from vechain/b3tr packages/contracts at the current main commit.